### PR TITLE
Enhancement: Only allow artemis urls

### DIFF
--- a/src/main/java/de/tum/www1/orion/ui/OrionRouter.java
+++ b/src/main/java/de/tum/www1/orion/ui/OrionRouter.java
@@ -1,5 +1,8 @@
 package de.tum.www1.orion.ui;
 
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+
 public interface OrionRouter {
     /**
      * Get the route for the currently opened exercise/project. The route is the full URL for the web browser, leading
@@ -15,4 +18,8 @@ public interface OrionRouter {
      * @return The URL leading to the ArTEMiS homepage
      */
     String defaultRoute();
+
+    static OrionRouter getInstance(Project project) {
+        return ServiceManager.getService(project, OrionRouter.class);
+    }
 }

--- a/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
+++ b/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
@@ -29,10 +29,5 @@ class OrionRouterService(private val project: Project): OrionRouter {
     companion object {
         private const val EXERCISE_DETAIL_URL = "/#/overview/%d/exercises/%d"
         private const val CODE_EDITOR_INSTRUCTOR_URL = "/#/code-editor/ide/%d/admin/%d"
-
-        @JvmStatic
-        fun getInstance(project: Project): OrionRouterService {
-            return ServiceManager.getService(project, OrionRouterService::class.java)
-        }
     }
 }

--- a/src/main/java/de/tum/www1/orion/ui/util/UrlAccessForbiddenWarning.kt
+++ b/src/main/java/de/tum/www1/orion/ui/util/UrlAccessForbiddenWarning.kt
@@ -1,0 +1,33 @@
+package de.tum.www1.orion.ui.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.layout.panel
+import de.tum.www1.orion.util.translate
+import javax.swing.Action
+import javax.swing.JComponent
+
+class UrlAccessForbiddenWarning(project: Project?) : DialogWrapper(project) {
+
+    init {
+        title = translate("orion.warning.accessforbidden")
+        setCrossClosesWindow(false)
+        init()
+        isOKActionEnabled = true
+    }
+
+    override fun createActions(): Array<Action> {
+        return arrayOf(okAction)
+    }
+
+    override fun createCenterPanel(): JComponent? {
+        return panel {
+            row {
+                label(translate("orion.warning.accessforbidden.message"), bold = true)
+            }
+            row {
+                label(translate("orion.warning.accessforbidden.backtoprevious"))
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,7 +44,8 @@
         <toolWindow id="Artemis" anchor="right" icon="/toolWindowIcon.png" factoryClass="de.tum.www1.orion.ui.browser.BrowserFactory" />
         <applicationService serviceInterface="de.tum.www1.orion.vcs.CredentialsService"
                             serviceImplementation="de.tum.www1.orion.vcs.CredentialsInjectorService"/>
-        <projectService serviceImplementation="de.tum.www1.orion.ui.OrionRouterService"/>
+        <projectService serviceInterface="de.tum.www1.orion.ui.OrionRouter"
+                        serviceImplementation="de.tum.www1.orion.ui.OrionRouterService"/>
         <projectService serviceInterface="de.tum.www1.orion.util.registry.OrionStudentExerciseRegistry"
                         serviceImplementation="de.tum.www1.orion.util.registry.DefaultOrionStudentExerciseRegistry"/>
         <projectService serviceInterface="de.tum.www1.orion.bridge.core.ArtemisCoreUpcallBridge"

--- a/src/main/resources/i18n/OrionBundle.properties
+++ b/src/main/resources/i18n/OrionBundle.properties
@@ -8,5 +8,8 @@ orion.settings.browser.debugActions=Useful Browser Actions
 orion.settings.browser.button.clearCache=Clear Cache
 orion.settings.browser.button.reload=Reload
 
-
 orion.dialog.pathchooser.title=Choose a path
+
+orion.warning.accessforbidden=Access Forbidden
+orion.warning.accessforbidden.message=Orion does not support opening pages outside of Artemis!
+orion.warning.accessforbidden.backtoprevious=You will be routed back to the previous page

--- a/src/main/resources/i18n/OrionBundle_de.properties
+++ b/src/main/resources/i18n/OrionBundle_de.properties
@@ -9,3 +9,7 @@ orion.settings.browser.button.clearCache=Cache Leeren
 orion.settings.browser.button.reload=Seite Neu Laden
 
 orion.dialog.pathchooser.title=Speicherort auswählen
+
+orion.warning.accessforbidden=Zugriff Verweigert
+orion.warning.accessforbidden.message=Orion unterstützt keinen Zugriff auf Seiten ausßerhalb von Artemis!
+orion.warning.accessforbidden.backtoprevious=Die vorherige Seite wird erneut geladen.


### PR DESCRIPTION
Depends on #17 
Resolves #13 
We now block opening external URLs and display a warning if a user tries to do so. On opening an external URL, the user will be rerouted to the previous page on Artemis