### PR TITLE
Bugfix/user agent init

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.jetbrains.intellij") version "0.4.21"
+    id("org.jetbrains.intellij") version "0.4.26"
     java
-    kotlin("jvm") version "1.3.72"
+    kotlin("jvm") version "1.4.10"
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -27,7 +27,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.2"
+    version = "2020.2.2"
     setPlugins("git4idea", "maven", "Pythonid:202.6397.98", "com.intellij.javafx:1.0.2")
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 group = "de.tum.www1.artemis.plugin.intellij"
-version = "1.0.1"
+version = "1.0.2"
 
 repositories {
     mavenCentral()
@@ -35,8 +35,8 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
       <p>
             <h2>Improvements and Bugfixes</h2>
             <ul>
-                <li>Upgrade to IntelliJ 2020.2</li>
-                <li>Switch to Gradle configuration via Kotlin</li>
+                <li>Upgrade to IntelliJ 2020.2.2</li>
+                <li>Fix user agent initialisation for new installs (caused crashes or didn't load Artemis)</li>
             </ul>
         </p>""")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,14 @@
+pluginManagement {
+    repositories {
+        maven{
+            setUrl("https://jetbrains.bintray.com/intellij-plugin-service")
+        }
+        maven {
+            setUrl("https://plugins.gradle.org/m2/")
+        }
+        mavenCentral()
+    }
+}
+
 rootProject.name = "orion"
 

--- a/src/main/java/de/tum/www1/orion/OrionStartupProjectRefreshActivity.kt
+++ b/src/main/java/de/tum/www1/orion/OrionStartupProjectRefreshActivity.kt
@@ -26,7 +26,7 @@ class OrionStartupProjectRefreshActivity : StartupActivity {
      * - Tell the ArTEMiS webapp that a new exercise was opened
      */
     override fun runActivity(project: Project) {
-        OrionSettingsProvider.initSettings()
+        appService(OrionSettingsProvider::class.java).initSettings()
         // We need to subscribe to all internal state listeners before any message could potentially be sent
         project.service(JavaScriptConnector::class.java).initIDEStateListeners()
         // If the exercise was opened for the first time

--- a/src/main/java/de/tum/www1/orion/settings/OrionSettingsProvider.java
+++ b/src/main/java/de/tum/www1/orion/settings/OrionSettingsProvider.java
@@ -1,8 +1,6 @@
 package de.tum.www1.orion.settings;
 
 import com.intellij.openapi.components.ServiceManager;
-import javafx.application.Platform;
-import javafx.scene.web.WebView;
 
 import java.io.File;
 import java.util.Map;
@@ -12,20 +10,17 @@ public interface OrionSettingsProvider {
     void saveSettings(Map<KEYS, String> settings);
     String getSetting(KEYS key);
     boolean isModified(Map<KEYS, String> settings);
+    void initSettings();
 
     static OrionSettingsProvider getInstance() {
         return ServiceManager.getService(OrionSettingsProvider.class);
-    }
-
-    static void initSettings() {
-        KEYS.initSettings();
     }
 
     enum KEYS {
         ARTEMIS_URL("de.tum.www1.orion.settings.artemis.url", "https://artemis.ase.in.tum.de"),
         PROJECT_BASE_DIR("de.tum.www1.orion.settings.projects.path", System.getProperty("user.home") + File.separatorChar + "ArtemisProjects"),
         INSTRUCTOR_BASE_DIR("de.tum.www1.orion.settings.projects.instructor.path", System.getProperty("user.home") + File.separatorChar + "ArtemisProjects" + File.separatorChar + "Instructor"),
-        USER_AGENT("de.tum.www1.orion.settings.userAgent", null);
+        USER_AGENT("de.tum.www1.orion.settings.userAgent", "Mozilla/5.0 (KHTML, like Gecko) JavaFX/10");
 
         private String keyValue;
         private String defaultValue;
@@ -42,18 +37,6 @@ public interface OrionSettingsProvider {
 
         public String getDefaultValue() {
             return defaultValue;
-        }
-
-        public static void initSettings() {
-            try {
-                Platform.startup(KEYS::initUserAgent);
-            } catch (IllegalStateException e) {
-                Platform.runLater(KEYS::initUserAgent);
-            }
-        }
-
-        private static void initUserAgent() {
-            KEYS.USER_AGENT.defaultValue = new WebView().getEngine().getUserAgent();
         }
     }
 }

--- a/src/main/java/de/tum/www1/orion/settings/OrionSettingsProviderService.kt
+++ b/src/main/java/de/tum/www1/orion/settings/OrionSettingsProviderService.kt
@@ -8,6 +8,8 @@ import de.tum.www1.orion.settings.OrionSettingsProvider.KEYS.USER_AGENT
 import de.tum.www1.orion.ui.browser.Browser
 import de.tum.www1.orion.util.appService
 import de.tum.www1.orion.util.service
+import javafx.application.Platform
+import javafx.scene.web.WebView
 
 class OrionSettingsProviderService : OrionSettingsProvider {
     private val properties: PropertiesComponent
@@ -41,5 +43,18 @@ class OrionSettingsProviderService : OrionSettingsProvider {
 
     override fun isModified(settings: Map<OrionSettingsProvider.KEYS, String>): Boolean {
         return settings.any { properties.getValue(it.key.toString()) != it.value }
+    }
+
+    override fun initSettings() {
+        try {
+            Platform.startup { initUserAgent() }
+        } catch (e: IllegalStateException) {
+            Platform.runLater { initUserAgent() }
+        }
+    }
+
+    private fun initUserAgent() {
+        val currentAgent = WebView().engine.userAgent
+        saveSetting(USER_AGENT, currentAgent)
     }
 }

--- a/src/main/resources/de/tum/www1/orion/Orion.properties
+++ b/src/main/resources/de/tum/www1/orion/Orion.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=1.0.2


### PR DESCRIPTION
Fixes the initialisation of the user agent in the embedded browser for new installs. Previously, the default value of `null`could cause crashes, or just a failed load of the Artemis website.

I also bumped the version compatibility to IntelliJ 2020.2.2

For testing, please install: [orion-1.0.2.zip](https://github.com/ls1intum/Orion/files/5252600/orion-1.0.2.zip)

1. Open IntelliJ with the installed plugin and open the embedded browser
2. Close IntelliJ and re-open it again, there should be no errors if you re-open the browser with Artemis, the site should load without problems
3. (Optional) Import an exercise and submit some changed code, the build and reported test results should get displayed properly in the IDE