### PR TITLE
Remove external webpage check

### DIFF
--- a/src/main/java/de/tum/www1/orion/ui/browser/BrowserService.kt
+++ b/src/main/java/de/tum/www1/orion/ui/browser/BrowserService.kt
@@ -73,7 +73,7 @@ class BrowserService(val project: Project) : IBrowser, Disposable {
         client = jbCefAppInstance.createClient()
         jbCefBrowser = JBCefBrowser(client, null)
         setUserAgentHandlerFor(userAgent)
-        alwaysCheckForValidArtemisUrl()
+        //alwaysCheckForValidArtemisUrl() Temporary removed for external logins.
         addArtemisWebappLoadedNotifier()
         client.addLoadHandler(object : CefLoadHandlerAdapter() {
             override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {


### PR DESCRIPTION
Closes #30 : Quick fix to issue #30 by temporarily remove the check to enable external logins. I plan to add a floating button that is visible when outside domain is detected that will let the user go back to the Artemis's homepage in the future.

@ungaralex I would like to keep this branch for further development. Please don't delete it after this PR.