### PR TITLE
Fixed Plugin for intelliJ 2020.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,15 @@ on:
   workflow_dispatch:
 jobs:
   gradle:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
         java-version: 15
+        kotlin-version:  1.4.10
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
     - run: ./gradlew build
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: eskatos/gradle-command-action@v1
+    - run: ./gradlew build
+    - uses: actions/upload-artifact@v2
       with:
-        arguments: build
+        name: Package
+        path: build/libs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,5 @@ jobs:
     - run: ./gradlew build
     - uses: actions/upload-artifact@v2
       with:
-        name: Package/orion/lib/
+        name: Package.orion.lib.
         path: build/libs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Autobuild Plugin
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ ubuntu-latest }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
@@ -22,9 +19,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 15
     - run: ./gradlew build
     - uses: actions/upload-artifact@v2
       with:
-        name: Package
+        name: Package/orion/lib/
         path: build/libs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ ubuntu-latest }}
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Open Artemis IDE plugin for the programming exercise integration.
 This plugin integrates the [Artemis](https://github.com/ls1intum/Artemis) interactive learning platform into the IntelliJ IDE.
 It allows you to directly import programming exercises from ArTEMiS and submit your changes to the build servers.
 
-**Current version:** 1.1.0
+**Current version:** 1.1.1
 
 ## Planned features
 We want to integrate the following features into the plugin:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.jetbrains.intellij") version "0.5.0"
+    id("org.jetbrains.intellij") version "0.6.5"
     java
     kotlin("jvm") version "1.4.10"
 }
@@ -16,7 +16,7 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 group = "de.tum.www1.artemis.plugin.intellij"
-version = "1.1.0"
+version = "1.1.1"
 
 repositories {
     mavenCentral()
@@ -24,28 +24,26 @@ repositories {
 
 dependencies {
     // JSON parsing
-    implementation("com.google.code.gson:gson:2.8.5")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.2")
+    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.0")
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.2.3"
-    setPlugins("git4idea", "maven", "Pythonid:202.6397.98")
+    version = "2020.3"
+    setPlugins("git4idea", "maven", "Pythonid:203.5981.155")
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     changeNotes(
         """
       <p>
-            <h2>Improvements and Bugfixes</h2>
+            <h2>Added Support f</h2>
             <ul>
-                <li>Upgrade to IntelliJ 2020.2.3</li>
-                <li>Migration to JCEF runtime. Dependency on JavaFx run time plugin is no longer needed </li>
-                <li>Fix user agent initialisation for new installs (caused crashes or didn't load Artemis)</li>
-                <li>Fix a crash caused by the old JavaFx runtime </li>
-                <li>Fix Artemis tool window UI mangling when moved to bottom </li>
-                <li>Partially fix the back button not working issue </li>
-                <li>General improvements in plugin stability </li>
+                <li>Upgrade to IntelliJ 2020.3</li>
+                <li>Upgraded to Gradle 0.6.5</li>
+                <li>Upgrade KotlinModule to Version 2.12.6</li>
+                <li>Upgrade Gson to Version 2.8.6</li>
+                <li>Upgrade Pythonid plugin to version 203.5981.155</li>
             </ul>
         </p>"""
     )


### PR DESCRIPTION
I just fixed the plugin to build properly for IntelliJ 2020.3.

But I must admit that its not a fix for the next releases and should be considered as a temporary solution.
Maybe an other version system should be considered