### PR TITLE
Update dependencies to 2021.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.4.31"
     id("org.jetbrains.intellij") version "0.7.2"
-    java
-    kotlin("jvm") version "1.4.31"
 }
 
 java {
@@ -29,8 +29,8 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.3.2"
-    setPlugins("git4idea", "maven", "Pythonid:203.5981.165")
+    version = "2021.1"
+    setPlugins("git4idea", "maven", "PythonCore:211.6693.115")
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     changeNotes(
@@ -39,9 +39,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
             <h1>Version Upgrade</h1>
             <h2>Improvements</h2>
             <ul>
-                <li>Upgrade to IntelliJ 2020.3</li>
-                <li>Upgrade various plugin dependencies</li>
-                <li>Allow access to external webpages (for the integration with self-hosted Artemis instances)</li>
+                <li>Upgrade to IntelliJ 2021.1</li>
             </ul>
         </p>"""
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.4.31"
-    id("org.jetbrains.intellij") version "0.7.2"
+    id("org.jetbrains.kotlin.jvm") version "1.4.32"
+    id("org.jetbrains.intellij") version "0.7.3"
 }
 
 java {
@@ -29,9 +29,10 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2021.1"
-    setPlugins("git4idea", "maven", "PythonCore:211.6693.115")
+    version = "2021.1.1"
+    setPlugins("git4idea", "maven", "PythonCore:211.6693.119")
 }
+
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     changeNotes(
         """
@@ -39,7 +40,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
             <h1>Version Upgrade</h1>
             <h2>Improvements</h2>
             <ul>
-                <li>Upgrade to IntelliJ 2021.1</li>
+                <li>Upgrade to IntelliJ 2021.1.1</li>
             </ul>
         </p>"""
     )

--- a/src/main/java/de/tum/www1/orion/dto/Course.kt
+++ b/src/main/java/de/tum/www1/orion/dto/Course.kt
@@ -22,7 +22,7 @@ data class Course(
 data class ProgrammingExercise(val id: Long, val title: String, val gradingInstructions: String, val shortName: String,
                                val releaseDate: ZonedDateTime?, val dueDate: ZonedDateTime?, val assessmentDueDate: ZonedDateTime?,
                                val maxScore: Int, val assessmentType: AssessmentType, val difficulty: DifficultyLevel?,
-                               val categories: List<String>?, val course: Course, val projectKey: String,
+                               val categories: List<ExerciseCategory>?, val course: Course, val projectKey: String,
                                val templateParticipation: ProgrammingExerciseParticipation,
                                val solutionParticipation: ProgrammingExerciseParticipation,
                                val testRepositoryUrl: URL,
@@ -30,5 +30,7 @@ data class ProgrammingExercise(val id: Long, val title: String, val gradingInstr
                                val programmingLanguage: ProgrammingLanguage, val packageName: String,
                                val problemStatement: String, val sequentialTestRuns: Boolean?,
                                val buildAndTestStudentSubmissionsAfterDueDate: ZonedDateTime?)
+
+data class ExerciseCategory(val category: String, val color: String)
 
 data class ProgrammingExerciseParticipation(val id: Long, val repositoryUrl: URL, val buildPlanId: String)

--- a/src/main/java/de/tum/www1/orion/vcs/OrionGitAdapter.kt
+++ b/src/main/java/de/tum/www1/orion/vcs/OrionGitAdapter.kt
@@ -6,6 +6,7 @@ import com.intellij.dvcs.repo.VcsRepositoryManager
 import com.intellij.dvcs.repo.VcsRepositoryMappingListener
 import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -26,7 +27,6 @@ import com.intellij.openapi.vcs.changes.VcsDirtyScopeManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.runInEdtAndWait
 import de.tum.www1.orion.dto.RepositoryType
 import de.tum.www1.orion.exercise.registry.OrionInstructorExerciseRegistry
 import de.tum.www1.orion.messaging.OrionIntellijStateNotifier
@@ -134,7 +134,7 @@ object OrionGitAdapter {
 
     fun submit(project: Project, withEmptyCommit: Boolean = true) : Boolean {
         return ProgressManager.getInstance().computeInNonCancelableSection(ThrowableComputable {
-            runInEdtAndWait { FileDocumentManager.getInstance().saveAllDocuments() }
+            WriteAction.runAndWait<Throwable> { FileDocumentManager.getInstance().saveAllDocuments() }
             getAllUntracked(project)
                 .takeIf { it.isNotEmpty() }
                 ?.let { addAll(project, it) }
@@ -156,7 +156,7 @@ object OrionGitAdapter {
 
     fun submit(module: Module, withEmptyCommit: Boolean = true) : Boolean{
         return ProgressManager.getInstance().computeInNonCancelableSection(ThrowableComputable {
-            runInEdtAndWait { FileDocumentManager.getInstance().saveAllDocuments() }
+            WriteAction.runAndWait<Throwable> { FileDocumentManager.getInstance().saveAllDocuments() }
             getAllUntracked(module).takeIf { it.isNotEmpty() }?.let { addAll(module.project, it) }
             val changeListManager = ChangeListManager.getInstance(module.project)
             val changes = ModuleRootManager.getInstance(module).contentRoots


### PR DESCRIPTION
### Description
Updates all dependencies to IntelliJ 2021.1.1. Python (Python for IntelliJ Ultimate) had to be replaced with PythonCore (Python for Intellij Community) to fix issues with dependencies; no functionality seems to be affected by this.

Also fixes #40.

### Steps for Testing
Version May 6: [orion.zip](https://github.com/ls1intum/Orion/files/6436333/orion.zip)

1. Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/master/README.md#installation-of-a-release-zip)
2. Check if all features still work (start exercise, submit changes, recieve test results)

Please add which IntelliJ version you tested with (Ultimate (IU) or Community (IC))