### PR TITLE
[chore] refactor connectors

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,10 +1,19 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/src/main/java/de/tum/www1/orion/connector/ide/OrionConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/OrionConnector.kt
@@ -2,6 +2,12 @@ package de.tum.www1.orion.connector.ide
 
 import com.intellij.ui.jcef.JBCefJSQuery
 import de.tum.www1.orion.ui.browser.IBrowser
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.callback.CefQueryCallback
+import org.cef.handler.CefLoadHandlerAdapter
+import org.cef.handler.CefMessageRouterHandlerAdapter
+import java.util.*
 
 /**
  * Represent a class which is responsible for initializing JS to Java communication
@@ -11,22 +17,32 @@ import de.tum.www1.orion.ui.browser.IBrowser
  * in JS this function and passing the message. If there are multiple handlers attached, a random handler will receive
  * the message. Propagation of message to other handlers is done by setting the return value of onQuery to false. To
  * make sure that the message is dispatched to the right handler, we use message of the form:
-      "handlerName \n param1 \n param2 \n param3 \n ...
+"handlerName \n param1 \n param2 \n param3 \n ...
  * See https://appdoc.app/artifact/org.bitbucket.johness/java-cef/49.87.win32.2/index.html?org/cef/handler/CefRequestHandler.html
  * for more information.
  *
  * @property connectorName the name of the javascript object which will be added into the window object so that user
  * interaction in the webpage is linked to Javascript handler, which then calls the corresponding Java handler via cefQuery
  */
-abstract class OrionConnector{
+abstract class OrionConnector {
     protected val connectorName: String
 
     init {
+        connectorName = setFirstLetterLowercase(this.javaClass.simpleName)
+    }
+
+    /**
+     * Sets the first letter of the given name to lower case
+     *
+     * @param name string to change
+     * @return the input string with the first letter lowercase
+     */
+    private fun setFirstLetterLowercase(name: String): String {
         // Most performant way to set the first letter to lowercase according to
         // https://stackoverflow.com/questions/4052840/most-efficient-way-to-make-the-first-character-of-a-string-lower-case
-        val classNameChars = this.javaClass.simpleName.toCharArray()
-        classNameChars[0] = Character.toLowerCase(classNameChars[0])
-        connectorName = String(classNameChars)
+        val nameChars = name.toCharArray()
+        nameChars[0] = Character.toLowerCase(nameChars[0])
+        return String(nameChars)
     }
 
     /**
@@ -35,4 +51,78 @@ abstract class OrionConnector{
      * @param queryInjector an injector which produces a cefQuery string of the right form to add into JS string
      */
     abstract fun initializeHandlers(browser: IBrowser, queryInjector: JBCefJSQuery)
+
+    /**
+     * Adds a handler connecting the javascript with kotlin. If a function is called with the name present
+     * in the map, the associated kotlin action is called with a scanner to allow the function to read
+     * further parameters
+     *
+     * @param browser the browser to add the handler to
+     * @param reactions mapping all functions to the kotlin function called if it is invoked
+     */
+    protected fun addJavaHandler(browser: IBrowser, reactions: Map<String, (Scanner) -> Unit>) {
+        browser.addJavaHandler(object : CefMessageRouterHandlerAdapter() {
+            override fun onQuery(
+                browser: CefBrowser?,
+                frame: CefFrame?,
+                queryId: Long,
+                request: String?,
+                persistent: Boolean,
+                callback: CefQueryCallback?
+            ): Boolean {
+                request ?: return false
+                val scanner = Scanner(request)
+                val methodName = scanner.nextLine()
+                val reaction = reactions[methodName] ?: return false
+                reaction.invoke(scanner)
+                return true
+            }
+        })
+    }
+
+    /**
+     * Generates the javascript half of the connectors and adds it to the browser
+     *
+     * @param browser the browser to inject the js into
+     * @param queryInjector the injector from initializeHandlers
+     * @param parameterNames mapping the function names to their parameter names
+     */
+    protected fun addLoadHandler(
+        browser: IBrowser,
+        queryInjector: JBCefJSQuery,
+        parameterNames: Map<String, List<String>>
+    ) {
+        // @formatter:off
+        /*
+         * Javascript looks as follows:
+         *   window.connector {
+         *     function1: function(parameter1, parameter2) {
+         *       $queryInjector.inject('function1' + '\n' + 'parameter1' + '\n' + 'parameter2')
+         *     },
+         *     function2 ...
+         *   }
+         *
+         * Make sure formatter control is activated before auto-formatting this file
+         */
+        val javaScript = """
+            window.$connectorName={
+                ${parameterNames.map {
+                    entry ->
+                        """${entry.key}: function(${entry.value.joinToString(", ")}) {
+                            ${queryInjector.inject("""
+                                '${entry.key}' ${entry.value.joinToString("") {
+                                    parameter -> " + '\\n' + $parameter"
+                                }}""".trimIndent())}
+                        }"""
+                }.joinToString(",\n")}
+            };
+        """.trimIndent()
+        // @formatter:on
+        println(javaScript)
+        browser.addLoadHandler(object : CefLoadHandlerAdapter() {
+            override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
+                browser?.executeJavaScript(javaScript, browser.url, 0)
+            }
+        })
+    }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/OrionConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/OrionConnector.kt
@@ -28,21 +28,11 @@ abstract class OrionConnector {
     protected val connectorName: String
 
     init {
-        connectorName = setFirstLetterLowercase(this.javaClass.simpleName)
-    }
-
-    /**
-     * Sets the first letter of the given name to lower case
-     *
-     * @param name string to change
-     * @return the input string with the first letter lowercase
-     */
-    private fun setFirstLetterLowercase(name: String): String {
         // Most performant way to set the first letter to lowercase according to
         // https://stackoverflow.com/questions/4052840/most-efficient-way-to-make-the-first-character-of-a-string-lower-case
-        val nameChars = name.toCharArray()
+        val nameChars = this.javaClass.simpleName.toCharArray()
         nameChars[0] = Character.toLowerCase(nameChars[0])
-        return String(nameChars)
+        connectorName = String(nameChars)
     }
 
     /**
@@ -118,7 +108,6 @@ abstract class OrionConnector {
             };
         """.trimIndent()
         // @formatter:on
-        println(javaScript)
         browser.addLoadHandler(object : CefLoadHandlerAdapter() {
             override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
                 browser?.executeJavaScript(javaScript, browser.url, 0)

--- a/src/main/java/de/tum/www1/orion/connector/ide/build/IOrionBuildConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/build/IOrionBuildConnector.kt
@@ -30,8 +30,4 @@ interface IOrionBuildConnector {
      * @param message Any message related to the test, which should be displayed on the console
      */
     fun onTestResult(success: Boolean, testName: String, message: String)
-
-    enum class FunctionName {
-        buildAndTestLocally, onBuildStarted, onBuildFinished, onBuildFailed, onTestResult
-    }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/exercise/IOrionExerciseConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/exercise/IOrionExerciseConnector.kt
@@ -15,8 +15,4 @@ interface IOrionExerciseConnector {
      * @param repositoryUrl The URL of the remote repository
      */
     fun importParticipation(repositoryUrl: String, exerciseJson: String)
-
-    enum class FunctionName {
-        editExercise, importParticipation
-    }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/exercise/OrionExerciseConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/exercise/OrionExerciseConnector.kt
@@ -10,63 +10,13 @@ import de.tum.www1.orion.exercise.OrionExerciseService
 import de.tum.www1.orion.ui.browser.IBrowser
 import de.tum.www1.orion.util.JsonUtils.gson
 import de.tum.www1.orion.util.nextAll
-import org.cef.browser.CefBrowser
-import org.cef.browser.CefFrame
-import org.cef.callback.CefQueryCallback
-import org.cef.handler.CefLoadHandlerAdapter
-import org.cef.handler.CefMessageRouterHandlerAdapter
 import java.util.*
 
 /**
  * Java handler for when an exercise is first opened
  */
 @Service
-class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExerciseConnector{
-
-    override fun initializeHandlers(browser: IBrowser, queryInjector: JBCefJSQuery) {
-        val editExerciseMethodName = IOrionExerciseConnector.FunctionName.editExercise.name
-        val importParticipationMethodName = IOrionExerciseConnector.FunctionName.importParticipation.name
-        browser.addJavaHandler(object : CefMessageRouterHandlerAdapter() {
-            override fun onQuery(
-                browser: CefBrowser?,
-                frame: CefFrame?,
-                queryId: Long,
-                request: String?,
-                persistent: Boolean,
-                callback: CefQueryCallback?
-            ): Boolean {
-                request ?: return false
-                val scanner = Scanner(request)
-                when (scanner.nextLine()) {
-                    editExerciseMethodName -> editExercise(scanner.nextAll())
-                    importParticipationMethodName -> {
-                        importParticipation(scanner.nextLine(), scanner.nextAll())
-                    }
-                    else -> return false
-                }
-                return true
-            }
-        })
-        browser.addLoadHandler(object : CefLoadHandlerAdapter() {
-            override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
-                browser?.executeJavaScript("""
-                    window.$connectorName={
-                        $editExerciseMethodName: function(exerciseJson) {
-                            ${queryInjector.inject("""
-                                '$editExerciseMethodName' + '\n' + exerciseJson
-                            """.trimIndent())}
-                        },
-                        $importParticipationMethodName: function(repositoryUrl, exerciseJson){
-                            ${queryInjector.inject("""
-                                '$importParticipationMethodName' + '\n' + repositoryUrl + '\n' + exerciseJson
-                            """.trimIndent())}
-                        }
-                    };
-                """, browser.url, 0)
-            }
-        })
-    }
-
+class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExerciseConnector {
     override fun editExercise(exerciseJson: String) {
         val exercise = gson().fromJson(exerciseJson, ProgrammingExercise::class.java)
         project.service<OrionExerciseService>().editExercise(exercise)
@@ -75,5 +25,17 @@ class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExe
     override fun importParticipation(repositoryUrl: String, exerciseJson: String) {
         val exercise = gson().fromJson(exerciseJson, ProgrammingExercise::class.java)
         project.service<OrionExerciseService>().importParticipation(repositoryUrl, exercise)
+    }
+
+    override fun initializeHandlers(browser: IBrowser, queryInjector: JBCefJSQuery) {
+        val reactions = mapOf("editExercise" to { scanner: Scanner -> editExercise(scanner.nextAll()) },
+            "importParticipation" to { scanner: Scanner -> importParticipation(scanner.nextLine(), scanner.nextAll()) })
+        addJavaHandler(browser, reactions)
+
+        val parameterNames = mapOf(
+            "editExercise" to listOf("exerciseJson"),
+            "importParticipation" to listOf("repositoryUrl", "exerciseJson")
+        )
+        addLoadHandler(browser, queryInjector, parameterNames)
     }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/shared/IOrionSharedUtilConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/shared/IOrionSharedUtilConnector.kt
@@ -17,8 +17,4 @@ interface IOrionSharedUtilConnector {
      * @param message A message to be logged in IntelliJ
      */
     fun log(message: String)
-
-    enum class FunctionName {
-        login, log
-    }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/vcs/IOrionVCSConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/vcs/IOrionVCSConnector.kt
@@ -9,8 +9,4 @@ interface IOrionVCSConnector {
      * @param repository The repository the instructor wants to focus on [de.tum.www1.orion.dto.RepositoryType]
      */
     fun selectRepository(repository: String)
-
-    enum class FunctionName {
-        submit, selectRepository
-    }
 }

--- a/src/main/java/de/tum/www1/orion/connector/ide/vcs/OrionVCSConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/vcs/OrionVCSConnector.kt
@@ -5,15 +5,9 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefJSQuery
 import de.tum.www1.orion.connector.ide.OrionConnector
-import de.tum.www1.orion.connector.ide.build.IOrionBuildConnector
 import de.tum.www1.orion.dto.RepositoryType
 import de.tum.www1.orion.exercise.registry.OrionInstructorExerciseRegistry
 import de.tum.www1.orion.ui.browser.IBrowser
-import org.cef.browser.CefBrowser
-import org.cef.browser.CefFrame
-import org.cef.callback.CefQueryCallback
-import org.cef.handler.CefLoadHandlerAdapter
-import org.cef.handler.CefMessageRouterHandlerAdapter
 import java.util.*
 
 @Service
@@ -21,8 +15,7 @@ class OrionVCSConnector(val project: Project) : OrionConnector(), IOrionVCSConne
 
     /**
      * This method now does nothing, the submitting is now delegated to onBuildStarted() so it has more information on
-     * whether or not the commit is successful and acts accordingly. The server always call onBuildStarted() after submit()
-     * any way.
+     * whether or not the commit is successful and acts accordingly. The server always calls onBuildStarted() after submit() anyways.
      */
     override fun submit() {
     }
@@ -33,48 +26,14 @@ class OrionVCSConnector(val project: Project) : OrionConnector(), IOrionVCSConne
     }
 
     override fun initializeHandlers(browser: IBrowser, queryInjector: JBCefJSQuery) {
-        browser.addJavaHandler(object : CefMessageRouterHandlerAdapter() {
-            override fun onQuery(browser: CefBrowser?, frame: CefFrame?, queryId: Long, request: String, persistent: Boolean, callback: CefQueryCallback?): Boolean {
-                val scanner = Scanner(request)
-                val methodName = scanner.nextLine()
-                val methodNameEnum = IOrionVCSConnector.FunctionName.values().find {
-                    it.name==methodName
-                } ?: return false
-                when (methodNameEnum) {
-                    IOrionVCSConnector.FunctionName.submit ->
-                        submit()
-                    IOrionVCSConnector.FunctionName.selectRepository ->
-                        selectRepository(scanner.nextLine())
-                }
-                return true
-            }
-        })
-        browser.addLoadHandler(object : CefLoadHandlerAdapter() {
-            override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
-                browser?.executeJavaScript(
-                    """
-                    window.$connectorName={
-                        ${IOrionVCSConnector.FunctionName.submit.name}: function() {
-                            ${
-                        queryInjector.inject(
-                            """
-                                '${IOrionVCSConnector.FunctionName.submit.name}'
-                            """.trimIndent()
-                        )
-                    }
-                        },
-                        ${IOrionVCSConnector.FunctionName.selectRepository}: function(repository){
-                            ${
-                        queryInjector.inject(
-                            """
-                                '${IOrionBuildConnector.FunctionName.onBuildStarted}' + '\n' + repository
-                            """.trimIndent()
-                        )
-                    }
-                        }
-                    };
-                """, browser.url, 0)
-            }
-        })
+        val reactions = mapOf("submit" to { submit() },
+            "selectRepository" to { scanner: Scanner -> selectRepository(scanner.nextLine()) })
+        addJavaHandler(browser, reactions)
+
+        val parameterNames = mapOf(
+            "submit" to listOf(),
+            "selectRepository" to listOf("repository")
+        )
+        addLoadHandler(browser, queryInjector, parameterNames)
     }
 }


### PR DESCRIPTION
### Motivation and Context
Resolves #29 

### Description
Adds two general purpose methods to add java and load handlers to OrionConnector which are then called by the subclasses, transferring the mapping between function names and data as maps.

Note the whole Orion-Artemis communication got reworked, it is therefore crucial to test all features to make sure they still work

### Steps for Testing
[orion46.zip](https://github.com/ls1intum/Orion/files/6479153/orion46.zip)

1. Run Orion
2. Check if all features still work (start and clone exercise, submit changes, receive test results, clone exercise as instructor)
