### PR TITLE
[Bugfix] Fix Back Button

### DIFF
--- a/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
+++ b/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
@@ -43,11 +43,11 @@ class OrionRouterService(private val project: Project) : OrionRouter {
     }
 
     companion object {
-        private const val EXERCISE_DETAIL_URL = "/#/courses/%d/exercises/%d"
+        private const val EXERCISE_DETAIL_URL = "/courses/%d/exercises/%d"
         private const val CODE_EDITOR_INSTRUCTOR_URL =
-            "/#/course-management/%d/programming-exercises/%d/code-editor/ide/%d"
-        private const val ASSESSMENT_DASHBOARD_URL = "/#/course-management/%d/assessment-dashboard/%d"
+            "/course-management/%d/programming-exercises/%d/code-editor/ide/%d"
+        private const val ASSESSMENT_DASHBOARD_URL = "/course-management/%d/assessment-dashboard/%d"
         private const val ASSESSMENT_CORRECTION_URL =
-            "/#/course-management/%d/programming-exercises/%d/submissions/%d/assessment"
+            "/course-management/%d/programming-exercises/%d/submissions/%d/assessment"
     }
 }


### PR DESCRIPTION
### Motivation, Context and Description
Solves #50 together with https://github.com/ls1intum/Artemis/pull/3630. Additionally to the broken back functionality, Orion is not connecting to the right url but instead to the url with a # in it, triggering a redirect which also messes up the history since now the page before the redirect is part of the history although it shouldn't. Removing the # solves that problem.

### Steps for Testing

1. Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/master/README.md#testing-of-pull-requests)
2. Deploy the mentioned Artemis Pr and set the correct testserver in Settings->Tools->Orion->Artemis URL
3. Start/Open an exercise as student
4. Press the back button after the project has opened before any other navigation happened
5. It should now navigate to the exercise overview