### PR TITLE
[Feature] Download Auxiliary Repositories

### DIFF
--- a/src/main/java/de/tum/www1/orion/dto/Course.kt
+++ b/src/main/java/de/tum/www1/orion/dto/Course.kt
@@ -19,18 +19,41 @@ data class Course(
     val registrationEnabled: Boolean, val presentationScore: Int, val maxComplaints: Int
 )
 
-data class ProgrammingExercise(val id: Long, val title: String, val gradingInstructions: String, val shortName: String,
-                               val releaseDate: ZonedDateTime?, val dueDate: ZonedDateTime?, val assessmentDueDate: ZonedDateTime?,
-                               val maxScore: Int, val assessmentType: AssessmentType, val difficulty: DifficultyLevel?,
-                               val categories: List<ExerciseCategory>?, val course: Course, val projectKey: String,
-                               val templateParticipation: ProgrammingExerciseParticipation,
-                               val solutionParticipation: ProgrammingExerciseParticipation,
-                               val testRepositoryUrl: URL,
-                               val publishBuildPlanUrl: Boolean, val allowOnlineEditor: Boolean,
-                               val programmingLanguage: ProgrammingLanguage, val packageName: String,
-                               val problemStatement: String, val sequentialTestRuns: Boolean?,
-                               val buildAndTestStudentSubmissionsAfterDueDate: ZonedDateTime?)
+data class ProgrammingExercise(
+    val id: Long,
+    val title: String,
+    val gradingInstructions: String,
+    val shortName: String,
+    val releaseDate: ZonedDateTime?,
+    val dueDate: ZonedDateTime?,
+    val assessmentDueDate: ZonedDateTime?,
+    val maxScore: Int,
+    val assessmentType: AssessmentType,
+    val difficulty: DifficultyLevel?,
+    val categories: List<ExerciseCategory>?,
+    val course: Course,
+    val projectKey: String,
+    val templateParticipation: ProgrammingExerciseParticipation,
+    val solutionParticipation: ProgrammingExerciseParticipation,
+    val testRepositoryUrl: URL,
+    val publishBuildPlanUrl: Boolean,
+    val allowOnlineEditor: Boolean,
+    val programmingLanguage: ProgrammingLanguage,
+    val packageName: String,
+    val problemStatement: String,
+    val sequentialTestRuns: Boolean?,
+    val auxiliaryRepositories: List<AuxiliaryRepository>?,
+    val buildAndTestStudentSubmissionsAfterDueDate: ZonedDateTime?
+)
 
 data class ExerciseCategory(val category: String, val color: String)
 
 data class ProgrammingExerciseParticipation(val id: Long, val repositoryUrl: URL, val buildPlanId: String)
+
+data class AuxiliaryRepository(
+    val id: Long,
+    val name: String,
+    val checkoutDirectory: String,
+    val repositoryUrl: URL,
+    val description: String
+)

--- a/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
+++ b/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
@@ -66,6 +66,12 @@ class OrionExerciseService(private val project: Project) {
             try {
                 // Create a new empty project
                 val projectPath = newEmptyProject(exercise.title, chosenPath)!!.basePath!!
+
+                exercise.auxiliaryRepositories?.also {
+                    project.notify(translate("orion.warning.auxiliaryRepositories"))
+                }?.forEach {
+                    clone(project, it.repositoryUrl.toString(), projectPath, "$projectPath/${it.checkoutDirectory}", null)
+                }
                 // Clone all base repositories
                 clone(
                     project, exercise.templateParticipation.repositoryUrl.toString(),

--- a/src/main/resources/i18n/OrionBundle.properties
+++ b/src/main/resources/i18n/OrionBundle.properties
@@ -26,6 +26,7 @@ orion.vcs.multipleremotes=Multiple remote branches detected. Your changes might 
 orion.exercise.submissiondeletionfailed=Deletion of submission failed. Retry.
 orion.exercise.submissiondownloadfailed=Downloading of submission failed due to heap size. Download manually from the web client or increase IntelliJ heap size.
 orion.exercise.submissiondownloading=Downloading Submission...
+orion.warning.auxiliaryRepositories=Auxiliary Repositories detected. Orion did download the repositories, but configuration of them is not yet supported.
 orion.warning.accessforbidden=Access Forbidden
 orion.warning.accessforbidden.message=Orion does not support opening pages outside of Artemis!
 orion.warning.accessforbidden.backtoprevious=You will be routed back to the previous page.

--- a/src/main/resources/i18n/OrionBundle_de.properties
+++ b/src/main/resources/i18n/OrionBundle_de.properties
@@ -26,6 +26,7 @@ orion.vcs.multipleremotes=Mehrere remote branches gefunden. Deine Änderungen wu
 orion.exercise.submissiondeletionfailed=Löschen der Abgabe fehlgeschlagen. Versuche es erneut.
 orion.exercise.submissiondownloadfailed=Herunterladen der Abgabe wegen heap-size fehlgeschlagen. Lade manuell vom web-client herunter oder erhöhe IntelliJ's heap-size.
 orion.exercise.submissiondownloading=Lade Abgabe herunter...
+orion.warning.auxiliaryRepositories=Auxiliary Repositories erkannt. Orion hat die Repositories heruntergeladen, aber ihre Konfiguration wird noch nicht unterstützt.
 orion.warning.accessforbidden=Zugriff Verweigert
 orion.warning.accessforbidden.message=Orion unterstützt keinen Zugriff auf Seiten außerhalb von Artemis!
 orion.warning.accessforbidden.backtoprevious=Die vorherige Seite wird erneut geladen.


### PR DESCRIPTION
### Motivation and Context
Solves part of #61. Auxiliary Repositories are now cloned along with the template, test, and solution repositories. However both the module and run configuration have to be done manually.

### Description
Also clones auxiliary repositories and displays a warning to inform the user of the lack of module and run configuration

### Steps for Testing
Has to be tested with [this](https://github.com/ls1intum/Artemis/pull/3859) PR

1.  Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/master/README.md#testing-of-pull-requests)
2.  Deploy the Artemis PR
3.  Open an exercise with auxiliary repositories as an instructor
4.  Verify a warning got shown
5.  Verify the repositories are present and usable
6. (Also download a different exercise without auxiliary repositories to ensure no regression happened)