### PR TITLE
[Enhancement] Assessment Improvements

### DIFF
--- a/src/main/java/de/tum/www1/orion/OrionStartupProjectRefreshActivity.kt
+++ b/src/main/java/de/tum/www1/orion/OrionStartupProjectRefreshActivity.kt
@@ -61,7 +61,7 @@ class OrionStartupProjectRefreshActivity : StartupActivity, DumbAware {
             project.messageBus.syncPublisher(OrionIntellijStateNotifier.INTELLIJ_STATE_TOPIC)
                 .openedExercise(exerciseInfo.exerciseId, exerciseInfo.currentView)
             when (exerciseInfo.currentView) {
-                ExerciseView.TUTOR -> OrionAssessmentUtils.makeStudentSubmissionAndTemplateReadonlyAndAddHeader(project)
+                ExerciseView.TUTOR -> OrionAssessmentUtils.configureEditorsForAssessment(project)
                 else -> Unit
             }
             project.service<OrionExerciseService>().updateExercise()

--- a/src/main/java/de/tum/www1/orion/exercise/OrionAssessmentService.kt
+++ b/src/main/java/de/tum/www1/orion/exercise/OrionAssessmentService.kt
@@ -1,6 +1,7 @@
 package de.tum.www1.orion.exercise
 
 import com.intellij.collaboration.ui.codereview.diff.EditorComponentInlaysManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.service
@@ -174,7 +175,7 @@ class OrionAssessmentService(private val project: Project) {
     }
 
     private fun closeAssessmentEditors(reopen: Boolean) {
-        runInEdt {
+        WriteAction.runAndWait<Throwable> {
             FileEditorManager.getInstance(project).let { manager ->
                 val selectedFile = manager.selectedEditor?.file
                 manager.allEditors.filterIsInstance<OrionAssessmentEditor>().map { it.file }

--- a/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
+++ b/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
@@ -14,7 +14,6 @@ import de.tum.www1.orion.exercise.OrionJavaInstructorProjectCreator.prepareProje
 import de.tum.www1.orion.exercise.registry.OrionGlobalExerciseRegistryService
 import de.tum.www1.orion.exercise.registry.OrionTutorExerciseRegistry
 import de.tum.www1.orion.messaging.OrionIntellijStateNotifier
-import de.tum.www1.orion.ui.browser.IBrowser
 import de.tum.www1.orion.ui.util.ImportPathChooser
 import de.tum.www1.orion.ui.util.YesNoChooser
 import de.tum.www1.orion.ui.util.notify
@@ -27,6 +26,7 @@ import de.tum.www1.orion.util.OrionFileUtils.storeBase64asFile
 import de.tum.www1.orion.util.OrionFileUtils.unzip
 import de.tum.www1.orion.util.OrionFileUtils.unzipSingleEntry
 import de.tum.www1.orion.util.OrionProjectUtil.newEmptyProject
+import de.tum.www1.orion.util.returnToExercise
 import de.tum.www1.orion.util.runWithIndeterminateProgressModal
 import de.tum.www1.orion.util.translate
 import de.tum.www1.orion.vcs.OrionGitAdapter
@@ -161,7 +161,7 @@ class OrionExerciseService(private val project: Project) {
                 if (downloadSubmissionInEdt(base64data)) {
                     // Update registry
                     registry.setSubmission(submissionId, correctionRound)
-                    project.service<IBrowser>().returnToExercise()
+                    returnToExercise(project)
                 } else {
                     // The clone state is overridden by the reload in the if case
                     project.messageBus.syncPublisher(OrionIntellijStateNotifier.INTELLIJ_STATE_TOPIC).isCloning(false)
@@ -169,7 +169,7 @@ class OrionExerciseService(private val project: Project) {
             }
         } else {
             // Return to assessment editor
-            project.service<IBrowser>().returnToExercise()
+            returnToExercise(project)
         }
     }
 

--- a/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
+++ b/src/main/java/de/tum/www1/orion/exercise/OrionExerciseService.kt
@@ -136,13 +136,15 @@ class OrionExerciseService(private val project: Project) {
         createProject(exercise, ExerciseView.TUTOR) { chosenPath, registry ->
             val parent = LocalFileSystem.getInstance().refreshAndFindFileByPath(chosenPath)!!.parent.path
             clone(project, exercise.testRepositoryUrl.toString(), parent, chosenPath) {
-                clone(
-                    project, exercise.templateParticipation.repositoryUrl.toString(),
-                    parent, "$chosenPath/$TEMPLATE"
-                ) {
+                // clone the template to use it to highlight the student code changes.
+                // disabled since the diff-view is currently not possible, see [OrionEditorProvider]
+                // clone(
+                //     project, exercise.templateParticipation.repositoryUrl.toString(),
+                //     parent, "$chosenPath/$TEMPLATE"
+                // ) {
                     registry.registerExercise(exercise, ExerciseView.TUTOR, chosenPath)
                     ProjectUtil.openOrImport(chosenPath, project, false)
-                }
+                // }
             }
         }
     }

--- a/src/main/java/de/tum/www1/orion/ui/OrionRouter.kt
+++ b/src/main/java/de/tum/www1/orion/ui/OrionRouter.kt
@@ -6,12 +6,18 @@ package de.tum.www1.orion.ui
 interface OrionRouter {
     /**
      * Get the route for the currently opened exercise/project. The route is the full URL for the web browser,
-     * leading to the exercise for students, the editor for instructors or the assessment dashboard/editor
-     * for tutors.
+     * leading to the exercise for students, the editor for instructors or the assessment dashboard/editor for tutors.
      *
      * If no Artemis exercise is opened, the configured base URL is returned
      *
      * @return The URL to the exercise in the Artemis webapp or the base URL if no Artemis exercise is opened
      */
     fun routeForCurrentExerciseOrDefault(): String
+
+    /**
+     * Get the route for the Orion documentation
+     *
+     * @return the URL of Orion's documentation
+     */
+    fun routeForDocumentation(): String
 }

--- a/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
+++ b/src/main/java/de/tum/www1/orion/ui/OrionRouterService.kt
@@ -42,6 +42,10 @@ class OrionRouterService(private val project: Project) : OrionRouter {
         }
     }
 
+    override fun routeForDocumentation(): String {
+        return "https://artemis-platform.readthedocs.io/en/latest/user/orion"
+    }
+
     companion object {
         private const val EXERCISE_DETAIL_URL = "/courses/%d/exercises/%d"
         private const val CODE_EDITOR_INSTRUCTOR_URL =

--- a/src/main/java/de/tum/www1/orion/ui/assessment/InlineAssessmentComment.kt
+++ b/src/main/java/de/tum/www1/orion/ui/assessment/InlineAssessmentComment.kt
@@ -17,7 +17,7 @@ import javax.swing.border.EmptyBorder
 /**
  * An Inline feedback comment. Works fairly independently, forwards relevant changes to the [OrionAssessmentService]
  *
- * @property feedback that is shown by the comment or null if the comment is creating a new feedback
+ * @property feedback that is shown by the comment. To create a new comment, use [OrionAssessmentService.addFeedbackCommentIfPossible]
  * @property relativePath of the file the comment is shown it, required to generate new feedback
  * @property line the comment is shown in, required to generate new feedback
  * @param inlaysManager of the editor the comment should be shown in; the comment creates and shows itself to obtain its own disposer
@@ -115,6 +115,7 @@ class InlineAssessmentComment(
             resetValues()
             isEditable = false
         } else {
+            project.service<OrionAssessmentService>().deletePendingFeedback(relativePath, line)
             disposer?.let {
                 Disposer.dispose(it)
             }

--- a/src/main/java/de/tum/www1/orion/ui/assessment/InlineAssessmentComment.kt
+++ b/src/main/java/de/tum/www1/orion/ui/assessment/InlineAssessmentComment.kt
@@ -1,11 +1,13 @@
 package de.tum.www1.orion.ui.assessment
 
+import com.intellij.collaboration.ui.codereview.diff.EditorComponentInlaysManager
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
+import com.intellij.openapi.fileTypes.FileTypes
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
-import com.intellij.collaboration.ui.codereview.diff.EditorComponentInlaysManager
+import com.intellij.ui.EditorTextField
 import de.tum.www1.orion.dto.Feedback
 import de.tum.www1.orion.exercise.OrionAssessmentService
 import de.tum.www1.orion.util.translate
@@ -39,7 +41,7 @@ class InlineAssessmentComment(
     private val coloredComponentList: List<JComponent>
 
     var component: JComponent = JPanel()
-    private var textArea: JTextArea = JTextArea(2, 0)
+    private var textField: EditorTextField
     private var spinner: JSpinner = JSpinner()
     private var buttonBar: JPanel = JPanel()
 
@@ -58,18 +60,22 @@ class InlineAssessmentComment(
             updateColor()
         }
 
+        project = inlaysManager.editor.project!!
+
+        textField = EditorTextField("", project, FileTypes.PLAIN_TEXT)
+        textField.setOneLineMode(false)
+        textField.border = null
+
         // TextAreas don't have a border by default, wrap into an extra panel to get one
         val textPanel = JPanel()
         textPanel.border = EmptyBorder(4, 4, 4, 4)
         textPanel.layout = BorderLayout()
-        textPanel.add(textArea, BorderLayout.CENTER)
+        textPanel.add(textField.component, BorderLayout.CENTER)
 
         component.layout = BorderLayout()
         component.add(textPanel, BorderLayout.CENTER)
         component.add(spinner, BorderLayout.EAST)
         component.add(buttonBar, BorderLayout.SOUTH)
-
-        project = inlaysManager.editor.project!!
 
         coloredComponentList =
             listOf(component, textPanel, spinner, buttonBar, editButton, saveButton, deleteButton, cancelButton)
@@ -81,28 +87,24 @@ class InlineAssessmentComment(
     }
 
     private fun updateGui() {
-        if (isEditable) {
-            textArea.isEditable = true
-            spinner.isEnabled = true
+        textField.isViewer = !isEditable
+        spinner.isEnabled = isEditable
+        buttonBar.removeAll()
 
-            buttonBar.removeAll()
+        if (isEditable) {
             buttonBar.add(cancelButton)
             if (feedback != null) {
                 buttonBar.add(deleteButton)
             }
             buttonBar.add(saveButton)
         } else {
-            textArea.isEditable = false
-            spinner.isEnabled = false
-
-            buttonBar.removeAll()
             buttonBar.add(editButton)
         }
         component.repaint()
     }
 
     private fun resetValues() {
-        textArea.text = feedback?.detailText ?: ""
+        textField.text = feedback?.detailText ?: ""
         spinner.value = feedback?.credits ?: 0
     }
 
@@ -137,13 +139,13 @@ class InlineAssessmentComment(
         if (feedback != null) {
             feedback?.let {
                 it.credits = spinnerValue
-                it.detailText = textArea.text
+                it.detailText = textField.text
             }
             project.service<OrionAssessmentService>().updateFeedback()
         } else {
             val newFeedback = Feedback(
                 spinnerValue,
-                textArea.text,
+                textField.text,
                 "file:${relativePath}_line:$line",
                 "File $relativePath at line ${line + 1}",
                 "MANUAL",

--- a/src/main/java/de/tum/www1/orion/ui/assessment/OrionEditorProvider.kt
+++ b/src/main/java/de/tum/www1/orion/ui/assessment/OrionEditorProvider.kt
@@ -37,10 +37,10 @@ class OrionEditorProvider : FileEditorProvider, DumbAware {
         /*
          Code that attempts to load the diff to the template, currently not functional.
          The created UnifiedDiffViewer only contains an EditorImpl with an empty document that cannot be used for the EditorRangeController
-         The github plugin solves this by unknown means, at the initialization of the
+         The GitHub plugin solves this by unknown means, at the initialization of the
          GHPREditorCommentableRangesController the provided EditorEx has an empty document,
          as expected, but when the initialized listener is called,
-         it suddenly contains text. I was however unable to find where this change happens.
+         it suddenly contains text. I was, however, unable to find where this change happens.
          */
         // val templateFile = VirtualFileManager.getInstance().refreshAndFindFileByNioPath(
         //     getTemplateOf(project).resolve(relativePath)

--- a/src/main/java/de/tum/www1/orion/ui/assessment/OrionEditorProvider.kt
+++ b/src/main/java/de/tum/www1/orion/ui/assessment/OrionEditorProvider.kt
@@ -18,7 +18,7 @@ import de.tum.www1.orion.util.translate
 /**
  * Registered in plugin.xml. Gets activated for all files in the assignment folder.
  * Upon opening such a file it will load the student submission file corresponding to the requested file and
- * generate a [OrionAssessmentEditor] that will allow to add assessment to it
+ * generate a [OrionAssessmentEditor] that will allow adding assessment to it
  * Tutors can switch between the [OrionAssessmentEditor] and the normal editor
  */
 class OrionEditorProvider : FileEditorProvider, DumbAware {

--- a/src/main/java/de/tum/www1/orion/ui/assessment/OrionGutterIconController.kt
+++ b/src/main/java/de/tum/www1/orion/ui/assessment/OrionGutterIconController.kt
@@ -60,11 +60,8 @@ class GutterIconRenderer(
         return object : AnAction() {
             override fun actionPerformed(e: AnActionEvent) {
                 // Only add comment if none exist in that line yet
-                if (inlaysManager.editor.project?.service<OrionAssessmentService>()?.getFeedbackFor(path)
-                        ?.any { it.line == line } == false
-                ) {
-                    InlineAssessmentComment(null, path, line, inlaysManager)
-                }
+                inlaysManager.editor.project?.service<OrionAssessmentService>()
+                    ?.addFeedbackCommentIfPossible(path, line, inlaysManager)
             }
         }
     }

--- a/src/main/java/de/tum/www1/orion/ui/browser/BrowserFactory.kt
+++ b/src/main/java/de/tum/www1/orion/ui/browser/BrowserFactory.kt
@@ -17,7 +17,12 @@ class BrowserFactory : ToolWindowFactory {
         val content = contentFactory.createContent(browserUIInitializationService, "", false)
         toolWindow.contentManager.addContent(content)
         val actionManager = ActionManager.getInstance()
-        toolWindow.setTitleActions(listOf(actionManager.getAction("de.tum.www1.orion.ui.browser.BrowserReturnAction")))
+        toolWindow.setTitleActions(
+            listOf(
+                actionManager.getAction("de.tum.www1.orion.ui.browser.BrowserHelpAction"),
+                actionManager.getAction("de.tum.www1.orion.ui.browser.BrowserReturnAction")
+            )
+        )
         browserUIInitializationService.init()
     }
 }

--- a/src/main/java/de/tum/www1/orion/ui/browser/BrowserHelpAction.kt
+++ b/src/main/java/de/tum/www1/orion/ui/browser/BrowserHelpAction.kt
@@ -3,17 +3,19 @@ package de.tum.www1.orion.ui.browser
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
-import de.tum.www1.orion.util.returnToExercise
+import de.tum.www1.orion.ui.OrionRouter
 
 /**
- * Action that returns to the currently opened exercise's page when used, enabled only after the browser loaded
+ * Action that opens Orion's documentation page, enabled only after the browser loaded
  */
-class BrowserReturnAction : AnAction() {
+class BrowserHelpAction : AnAction() {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = (e.project?.service<IBrowser>()?.isInitialized ?: false)
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-        e.project?.let { returnToExercise(it) }
+        e.project?.let {
+            it.service<IBrowser>().loadUrl(it.service<OrionRouter>().routeForDocumentation())
+        }
     }
 }

--- a/src/main/java/de/tum/www1/orion/ui/browser/BrowserService.kt
+++ b/src/main/java/de/tum/www1/orion/ui/browser/BrowserService.kt
@@ -16,9 +16,9 @@ import de.tum.www1.orion.connector.ide.vcs.OrionVCSConnector
 import de.tum.www1.orion.exercise.registry.OrionStudentExerciseRegistry
 import de.tum.www1.orion.messaging.OrionIntellijStateNotifier
 import de.tum.www1.orion.settings.OrionSettingsProvider
-import de.tum.www1.orion.ui.OrionRouter
 import de.tum.www1.orion.util.cefRouter
 import de.tum.www1.orion.util.getPrivateProperty
+import de.tum.www1.orion.util.returnToExercise
 import org.cef.CefApp
 import org.cef.CefSettings
 import org.cef.browser.CefBrowser
@@ -77,7 +77,7 @@ class BrowserService(val project: Project) : IBrowser, Disposable {
         // loading happens, if it's too late, then the window.cefQuery object won't be injected by JCEF
         injectJSBridge()
         // Only load any URL at the end to make sure that all handlers are registered
-        returnToExercise()
+        returnToExercise(project)
     }
 
     private fun setUserAgentHandlerFor(userAgent: String) {
@@ -111,10 +111,9 @@ class BrowserService(val project: Project) : IBrowser, Disposable {
         }, jbCefBrowser.cefBrowser)
     }
 
-    override fun returnToExercise() {
+    override fun loadUrl(url: String) {
         if (isInitialized) {
-            val route = project.service<OrionRouter>().routeForCurrentExerciseOrDefault()
-            jbCefBrowser.loadURL(route)
+            jbCefBrowser.loadURL(url)
             val service = project.service<OrionStudentExerciseRegistry>()
             if (service.isArtemisExercise) {
                 service.exerciseInfo?.let {

--- a/src/main/java/de/tum/www1/orion/ui/browser/IBrowser.kt
+++ b/src/main/java/de/tum/www1/orion/ui/browser/IBrowser.kt
@@ -30,7 +30,9 @@ interface IBrowser {
     fun init()
 
     /**
-     * Makes the browser return to the exercise, used to come back from external webpages
+     * Makes the browser load the given url
+     *
+     * @param url to load
      */
-    fun returnToExercise()
+    fun loadUrl(url: String)
 }

--- a/src/main/java/de/tum/www1/orion/util/Utils.kt
+++ b/src/main/java/de/tum/www1/orion/util/Utils.kt
@@ -1,6 +1,7 @@
 package de.tum.www1.orion.util
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -9,6 +10,8 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.ui.jcef.JBCefJSQuery
 import de.tum.www1.orion.enumeration.ProgrammingLanguage
 import de.tum.www1.orion.settings.OrionBundle
+import de.tum.www1.orion.ui.OrionRouter
+import de.tum.www1.orion.ui.browser.IBrowser
 import org.cef.browser.CefMessageRouter
 import org.jetbrains.concurrency.runAsync
 import java.util.*
@@ -109,4 +112,14 @@ fun runWithIndeterminateProgressModal(project: Project, descriptionKey: String, 
             task.run()
         }
     })
+}
+
+/**
+ * Makes the browser return to the default url as defined by [OrionRouter.routeForCurrentExerciseOrDefault]
+ *
+ * @param project the browser belongs to
+ */
+fun returnToExercise(project: Project) {
+    val url = project.service<OrionRouter>().routeForCurrentExerciseOrDefault()
+    project.service<IBrowser>().loadUrl(url)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,5 +64,8 @@
         <action id="de.tum.www1.orion.ui.browser.BrowserReturnAction"
                 class="de.tum.www1.orion.ui.browser.BrowserReturnAction" icon="AllIcons.Actions.Back">
         </action>
+        <action id="de.tum.www1.orion.ui.browser.BrowserHelpAction"
+                class="de.tum.www1.orion.ui.browser.BrowserHelpAction" icon="AllIcons.Actions.Help">
+        </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/i18n/OrionBundle.properties
+++ b/src/main/resources/i18n/OrionBundle.properties
@@ -54,5 +54,6 @@ orion.error.sdk.notAvailable=Can not find a project SDK for the current project.
 orion.error.vcs.nodefaultroot=No default root repository, cannot create empty commit!
 orion.error.outdatedartemisfolder=Your Artemis Folder state information is outdated. Please back it up if necessary and reopen the plugin in a blank project.
 orion.error.file.loaded=File failed to load.
+orion.error.file.noAssignmentEquivalent=Could not open the file because it does not exist in the assignment directory. Make sure the file exists in your assignment directory and retry.
 action.de.tum.www1.orion.ui.browser.BrowserReturnAction.text=Return To Exercise
 action.de.tum.www1.orion.ui.browser.BrowserHelpAction.text=Open The Documentation

--- a/src/main/resources/i18n/OrionBundle.properties
+++ b/src/main/resources/i18n/OrionBundle.properties
@@ -54,4 +54,5 @@ orion.error.sdk.notAvailable=Can not find a project SDK for the current project.
 orion.error.vcs.nodefaultroot=No default root repository, cannot create empty commit!
 orion.error.outdatedartemisfolder=Your Artemis Folder state information is outdated. Please back it up if necessary and reopen the plugin in a blank project.
 orion.error.file.loaded=File failed to load.
-action.de.tum.www1.orion.ui.browser.BrowserReturnAction.text=Return to Exercise
+action.de.tum.www1.orion.ui.browser.BrowserReturnAction.text=Return To Exercise
+action.de.tum.www1.orion.ui.browser.BrowserHelpAction.text=Open The Documentation

--- a/src/main/resources/i18n/OrionBundle_de.properties
+++ b/src/main/resources/i18n/OrionBundle_de.properties
@@ -55,3 +55,4 @@ orion.error.vcs.nodefaultroot=Kein Default Root Repository verfügbar, leerer Co
 orion.error.outdatedartemisfolder=Die Artemis Aufgaben Dateistruktur ist veraltet. Der aktuelle Ordner sollte gesichert und IntelliJ in einem leeren Projekt neu gestartet werden.
 orion.error.file.loaded=Datei konnte nicht geladen werden.
 action.de.tum.www1.orion.ui.browser.BrowserReturnAction.text=Kehre zur Aufgabe zurück
+action.de.tum.www1.orion.ui.browser.BrowserHelpAction.text=Öffne die Dokumentation

--- a/src/main/resources/i18n/OrionBundle_de.properties
+++ b/src/main/resources/i18n/OrionBundle_de.properties
@@ -54,5 +54,6 @@ orion.error.sdk.notAvailable=Keine SDK für das aktuelle Projekt verfügbar. SDK
 orion.error.vcs.nodefaultroot=Kein Default Root Repository verfügbar, leerer Commit kann nicht erzeugt werden!
 orion.error.outdatedartemisfolder=Die Artemis Aufgaben Dateistruktur ist veraltet. Der aktuelle Ordner sollte gesichert und IntelliJ in einem leeren Projekt neu gestartet werden.
 orion.error.file.loaded=Datei konnte nicht geladen werden.
+orion.error.file.noAssignmentEquivalent=Konnte die Datei nicht öffnen, da sie nicht im "assignment"-Ordner existiert. Stelle sicher, dass die Datei im "assignment"-Ordner existiert und versuche es erneut.
 action.de.tum.www1.orion.ui.browser.BrowserReturnAction.text=Kehre zur Aufgabe zurück
 action.de.tum.www1.orion.ui.browser.BrowserHelpAction.text=Öffne die Dokumentation


### PR DESCRIPTION
### Motivation and Context
This PR includes various improvements for the assessment in Orion.

### Description
The PR features the following changes:
 - Assessment comments in Orion now support the full functionality of text fields, including pasting, the arrow keys and deletion, all of which were unavalable before
 - The Orion toolwindow now has an additional button that loads the documentation page (will only work after https://github.com/ls1intum/Artemis/pull/4044 got merged)
 - It is not possible anymore to add multiple assessment comments in the same line, even if they are not yet saved
 - Opening files from the studentSubmission direcctory will now open the same editor as if they are opened from assigment
 - The temple repository no longer gets downloaded (it was planned to use it to calculate the student's changes and highlight them, but the highlighting proved to be more difficult than anticipated and had to be postpüoned. Until it is implemented, the template is not needed)

### Steps for Testing

1.  Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/master/README.md#testing-of-pull-requests)
2.  Assess an exercise in Orion
3. Make sure the described features work
4. No directory temple should be downloaded for new assessment projects
5. It should not be possible to add multple assessment comments in the same line
6. The comment field should support every possible text interaction
7. Opening files from studentSubmission shouuld open the regular assessment editor
8. Clicking the question mark at the top of the toolwindow should open the documentation