### PR TITLE
`Bugfix`: Fix json escaping

### DIFF
--- a/src/main/java/de/tum/www1/orion/connector/client/ArtemisClientConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/client/ArtemisClientConnector.kt
@@ -67,6 +67,7 @@ class ArtemisClientConnector(private val project: Project) : JavaScriptConnector
     }
 
     private fun executeJSFunction(function: JavaScriptFunction, vararg args: Any) {
+        // doubly escape all backslashes to counter some strange escaping and unescaping done by javascript when calling the connector
         val executeString = function.executeString(*args).replace("\\", "\\\\")
         if (!::browser.isInitialized) {
             dispatchQueue.add(executeString)

--- a/src/main/java/de/tum/www1/orion/connector/client/ArtemisClientConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/client/ArtemisClientConnector.kt
@@ -67,7 +67,7 @@ class ArtemisClientConnector(private val project: Project) : JavaScriptConnector
     }
 
     private fun executeJSFunction(function: JavaScriptFunction, vararg args: Any) {
-        val executeString = function.executeString(*args)
+        val executeString = function.executeString(*args).replace("\\", "\\\\")
         if (!::browser.isInitialized) {
             dispatchQueue.add(executeString)
             return

--- a/src/main/java/de/tum/www1/orion/connector/ide/exercise/IOrionExerciseConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/exercise/IOrionExerciseConnector.kt
@@ -24,7 +24,10 @@ interface IOrionExerciseConnector {
      * @param testRun true if in a test run, also needed for navigation
      * @param base64data data of the zip file containing the student's repository
      */
-    fun downloadSubmission(submissionId: Long, correctionRound: Long, testRun: Boolean, base64data: String)
+    // Uncomment this to activate transfer of the testRun flag
+    // THIS IS A BREAKING CHANGE that will require a matching Artemis version
+    // fun downloadSubmission(submissionId: Long, correctionRound: Long, testRun: Boolean, base64data: String)
+    fun downloadSubmission(submissionId: Long, correctionRound: Long, base64data: String)
 
     /**
      * Initializes the [OrionAssessmentService] with all current feedback

--- a/src/main/java/de/tum/www1/orion/connector/ide/exercise/OrionExerciseConnector.kt
+++ b/src/main/java/de/tum/www1/orion/connector/ide/exercise/OrionExerciseConnector.kt
@@ -37,8 +37,12 @@ class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExe
         project.service<OrionExerciseService>().assessExercise(exercise)
     }
 
-    override fun downloadSubmission(submissionId: Long, correctionRound: Long, testRun: Boolean, base64data: String) {
-        project.service<OrionExerciseService>().downloadSubmission(submissionId, correctionRound, testRun, base64data)
+    // Uncomment this to activate transfer of the testRun flag
+    // THIS IS A BREAKING CHANGE that will require a matching Artemis version
+    // Also uncomment further down
+    // override fun downloadSubmission(submissionId: Long, correctionRound: Long, testRun: Boolean, base64data: String) {
+    override fun downloadSubmission(submissionId: Long, correctionRound: Long, base64data: String) {
+        project.service<OrionExerciseService>().downloadSubmission(submissionId, correctionRound, false, base64data)
     }
 
     override fun initializeAssessment(submissionId: Long, feedback: String) {
@@ -55,8 +59,8 @@ class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExe
                     downloadSubmission(
                         scanner.nextLine().toLong(),
                         scanner.nextLine().toLong(),
-                        scanner.nextLine().toBoolean(),
-                        scanner.nextAll()
+                        // scanner.nextLine().toBoolean(),
+                        scanner.nextAll(),
                     )
                 } catch (e: OutOfMemoryError) {
                     // Error handling has to be this high level since the heap size error is thrown by scanner.nextAll()
@@ -74,7 +78,10 @@ class OrionExerciseConnector(val project: Project) : OrionConnector(), IOrionExe
             "editExercise" to listOf("exerciseJson"),
             "importParticipation" to listOf("repositoryUrl", "exerciseJson"),
             "assessExercise" to listOf("exerciseJson"),
-            "downloadSubmission" to listOf("submissionId", "correctionRound", "testRun", "downloadURL"),
+            "downloadSubmission" to listOf(
+                "submissionId", "correctionRound", //"testRun",
+                "downloadURL"
+            ),
             "initializeAssessment" to listOf("submissionId", "feedback")
         )
         addLoadHandler(browser, queryInjector, parameterNames)


### PR DESCRIPTION
### Motivation, Context and Description
Fixes #73.

The problem is caused by insuffiecient escaping. Gson correctly escapes the quotes inside the string as `\"`, but for reasons I do not understand, the artemis connector receives all quotes as `\"`, both inside the string and the ones part of the json. Therefore it cannot distinguish them anymore and the parsing crashes, leading to the described bug. To counter this, all backslashes get replaced by double backslashes before sending the data to the connector.

Also comments breaking changes regarding the testRun flag that would otherwise cause syncronisation issue with Orion's and Artemis's releases.

### Steps for Testing

1.  Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/master/README.md#testing-of-pull-requests)
2.  Test with the latest develop
3.  Assess an exercise
4.  Add all sorts of special characters into the feedback
5.  Verify the feedback gets stored correctly on the server, e.g. by opening the same submission in the browser