### PR TITLE
Update dependencies for IntelliJ 2022.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("java")
     kotlin("jvm") version "1.6.21"
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.10.0"
 }
 
 java {
@@ -29,15 +29,15 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2022.2.2")
-    plugins.set(listOf("git4idea", "maven", "PythonCore:222.4167.29"))
+    version.set("2022.3")
+    plugins.set(listOf("Git4Idea", "maven", "PythonCore:223.7571.123"))
 }
 
 tasks {
     patchPluginXml {
         // Last 2 digits of the year and the major version digit, 211-211.* equals (20)21.1.*
         // See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-        sinceBuild.set("222")
+        sinceBuild.set("223")
         // Orion Plugin version. Needs to be incremented for every new release!
         version.set("1.2.1")
         changeNotes.set(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/tum/www1/orion/util/OrionProjectUtil.kt
+++ b/src/main/java/de/tum/www1/orion/util/OrionProjectUtil.kt
@@ -27,7 +27,7 @@ object OrionProjectUtil {
     fun newEmptyProject(name: String, path: @SystemIndependent String): Project? {
         val projectManager = ProjectManagerEx.getInstanceEx()
         val realPath = Paths.get(FileUtil.toSystemDependentName(path))
-        val projectTask = OpenProjectTask(projectName = name)
+        val projectTask = OpenProjectTask().withProjectName(name);
 
         val newProject = projectManager.newProject(realPath, projectTask)
         newProject?.save()


### PR DESCRIPTION
### Motivation and Context
This PR updates the dependencies to be compatible with IntelliJ 2022.3.

### Description
<!-- Describe your changes in detail -->
This pull request updates Gradle to the latest version (7.6), the IntelliJ Gradle Plugin to 1.10.0, the PythonCore Plugin to the newest version (223.7571.123) and sets the IntelliJ version to 2022.3.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Install the release as described in [the readme](https://github.com/ls1intum/Orion/blob/main/README.md#testing-of-pull-requests)
2. Check that typical functions work with the newest Version of IntelliJ.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
